### PR TITLE
[Fix] Changed array comparison method 

### DIFF
--- a/js/AI/antiChessAI.js
+++ b/js/AI/antiChessAI.js
@@ -9,7 +9,7 @@ function antiChessAI(chess, turn){
         }
     }
 
-    if(captures === []){
+    if(captures == ""){
         minimaxAI(chess, turn, 3);
         return;
     }


### PR DESCRIPTION
When captures is an empty array, `captures === [ ]` returns false.
I believe that is the reason for the bug.
The fix simply changes it so that `captures` is compared against an empty string instead so that `captures == ""` return true, when `captures` is empty.


Confirmed it fixes issue #1 after allowing Antichess to play against minimax 10 times.
Seems to do the trick.